### PR TITLE
Adding proper order to V1 users action list to prioritize deactivation of  V1 users.

### DIFF
--- a/VersionOne.Provisioning.Tests/ManagerTests.cs
+++ b/VersionOne.Provisioning.Tests/ManagerTests.cs
@@ -87,6 +87,21 @@ namespace VersionOne.Provisioning.Tests {
             }
         }
 
+        [Test]
+        public void TestCompareUsersOrder() {
+            IDictionary<string, User> usersFromLdap = testUserFactory.CreateTestLdapUsers(false);
+            Assert.AreEqual(5, usersFromLdap.Count); //make sure the usersFromLdap List was populated correctly
+        
+            IDictionary<string, User> usersFromV1 = testUserFactory.CreateTestV1Users(false);
+            Assert.AreEqual(4, usersFromV1.Count); //make sure the V1 users List was populated correctly
+        
+            IList<User> usersToAction = manager.CompareUsers(usersFromLdap, usersFromV1);
+        
+            Assert.AreEqual(5, usersToAction.Count);
+        
+            CheckUser(usersToAction[0], "tom"); // make sure that Deactivation of users is first in the list
+        }
+
         private static void CheckUser(User user, string userName) {
             switch (userName) {
                 case "abe":

--- a/VersionOne.Provisioning/Manager.cs
+++ b/VersionOne.Provisioning/Manager.cs
@@ -81,8 +81,11 @@ namespace VersionOne.Provisioning {
                                         IDictionary<string, User> versionOneUsers) {
             List<User> v1ActionList = new List<User>();
 
+            List<User> v1UsersToCreate = new List<User>();
             int countUsersToCreate = 0;
+            List<User> v1UsersToReactivate = new List<User>();
             int countUsersToReactivate = 0;
+            List<User> v1UsersToDeactivate = new List<User>();
             int countUsersToDeactivate = 0;
 
             //Look for a match using directory as the master list...
@@ -96,13 +99,13 @@ namespace VersionOne.Provisioning {
                         //so it needs to be reactivated in V1.
                         userInV1.Reactivate = true;
                         userInV1.Email = directoryUser.Email;
-                        v1ActionList.Add(userInV1);
+                        v1UsersToReactivate.Add(userInV1);
                         countUsersToReactivate++;
                     }
                 } else {
                     //This directory user is not in V1, so it needs to be created in V1.
                     directoryUser.Create = true;
-                    v1ActionList.Add(directoryUser);
+                    v1UsersToCreate.Add(directoryUser);
                     countUsersToCreate++;
                 }
             }
@@ -116,11 +119,17 @@ namespace VersionOne.Provisioning {
                         //This V1 user is not in Ldap, but is active in V1, 
                         //so it needs to be deactivated in V1.
                         userInV1.Deactivate = true;
-                        v1ActionList.Add(userInV1);
+                        v1UsersToDeactivate.Add(userInV1);
                         countUsersToDeactivate++;
                     }
                 }
             }
+
+            // Put V1 users to deactivate in the list first
+            v1ActionList.AddRange(v1UsersToDeactivate);
+            // Add the rest of the users
+            v1ActionList.AddRange(v1UsersToReactivate);
+            v1ActionList.AddRange(v1UsersToCreate);
 
             logger.Info(countUsersToCreate + " Directory users have been marked for creation in VersionOne.");
             logger.Info(countUsersToDeactivate + " VersionOne users have been marked for deactivation.");


### PR DESCRIPTION
Pull request of fix for Issue https://github.com/versionone/VersionOne.Provisioning.LDAP/issues/10

Adding proper order to V1 users action list to prioritize deactivation of  V1 users.
